### PR TITLE
Small fix

### DIFF
--- a/src/utils/cron.sh
+++ b/src/utils/cron.sh
@@ -29,7 +29,7 @@ ROOT=${SRC::-3}
 date "+%D %T:%N" >> $ROOT.log
 
 # Add line to crontab
-JOB="@reboot source ${ROOT}update.sh $ROOT 2>>$ROOT.log"
+JOB="@reboot source ${ROOT}update.sh $ROOT"
 ( sudo crontab -u $USER -l; echo $JOB ) | sudo crontab -u $USER - 2>/dev/null
 
 # Find the content and print it line by line


### PR DESCRIPTION
Wrong errors were sent to wrong path.

Previously errors were sent to `.errors`, now the path is `.log`. If you have the cronjob enabled, you'll have to `up -au` to remove it, and then again `up -au` to re-enable it. Moreover, the last piece of line sent wrong results to `.log`, so I removed it.